### PR TITLE
Horsey 'KEY_TAB' behaviour

### DIFF
--- a/horsey.es5.js
+++ b/horsey.es5.js
@@ -665,7 +665,7 @@ function autocomplete(el) {
         show();
       }
     } else if (shown) {
-      if (which === KEY_ENTER) {
+      if (which === KEY_ENTER || which === KEY_TAB) {
         if (selection) {
           _crossvent2.default.fabricate(selection, 'click');
         } else {

--- a/horsey.js
+++ b/horsey.js
@@ -608,7 +608,7 @@ function autocomplete (el, options = {}) {
         show();
       }
     } else if (shown) {
-      if (which === KEY_ENTER) {
+      if (which === KEY_ENTER || which === KEY_TAB) {
         if (selection) {
           crossvent.fabricate(selection, 'click');
         } else {


### PR DESCRIPTION
This will make horsey work as a Google search input and accept chosen horsey proposition not only by 'KEY_ENTER', but by 'KEY_TAB' as well. This solution is a11y friendly. 